### PR TITLE
Frontend for multiple recipients and to change admin

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,10 +119,22 @@
                         </div>
 
                     </div>
-
-
-                    
                     <button type="submit" class="btn btn-primary" id="recipient_submit_btn" disabled="true">Keplr Loading <div class="spinner-border spinner-border-sm" role="status"></div></button>
+                </form>
+
+                <br/>
+                <h6>New Admin</h6>
+                <form name="adminForm" id="adminForm">
+
+                    <div class="form-row mb-3">
+
+                        <div class="col">
+                            <input type="text" class="form-control" id="new_admin" name="new_admin" placeholder="secret1...">
+                        </div>
+
+                    </div>
+
+                    <button type="submit" class="btn btn-primary" id="admin_submit_btn" disabled="true">Keplr Loading <div class="spinner-border spinner-border-sm" role="status"></div></button>
                 </form>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <body>
         <div id="app">
             <div class="container-sm">
-                <div class="col-md-6">
+                <div class="col-md-8">
                 <b>Contract Address:</b>
                 <div id="contract_address">
                     Loading
@@ -32,12 +32,97 @@
                 </div>
                 <br/>
                 
+                <h6>New Recipients</h6>
                 <form name="distForm" id="distForm">
-                    <div class="form-group">
-                        <label for="recipient">New Recipient Address</label>
-                        <input class="form-control" id="recipient" name="recipient" placeholder="secret1..." style="width: 400px;">
+
+                    <div class="form-row mb-3">
+
+                        <div class="col">
+                            <input type="text" class="form-control" id="recipient1" name="recipient1" placeholder="Recipient #1">
+                        </div>
+
+                        <div class="col-3">
+                            <div class="input-group">
+                                <input class="form-control" id="amount1" name="amount1" placeholder="Amount">
+                                <div class="input-group-append">
+                                    <div class="input-group-text">%</div>
+                                </div>
+                            </div>
+                        </div>
+
                     </div>
-                    <button type="submit" class="btn btn-primary" id="submit_btn" disabled="true">Keplr Loading <div class="spinner-border spinner-border-sm" role="status"></div></button>
+
+                    <div class="form-row mb-3">
+
+                        <div class="col">
+                            <input type="text" class="form-control" id="recipient2" name="recipient2" placeholder="Recipient #2 (Optional)">
+                        </div>
+
+                        <div class="col-3">
+                            <div class="input-group">
+                                <input class="form-control" id="amount2" name="amount2">
+                                <div class="input-group-append">
+                                    <div class="input-group-text">%</div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+
+                    <div class="form-row mb-3">
+
+                        <div class="col">
+                            <input type="text" class="form-control" id="recipient3" name="recipient3" placeholder="Recipient #3 (Optional)">
+                        </div>
+
+                        <div class="col-3">
+                            <div class="input-group">
+                                <input class="form-control" id="amount3" name="amount3">
+                                <div class="input-group-append">
+                                    <div class="input-group-text">%</div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+
+                    <div class="form-row mb-3">
+
+                        <div class="col">
+                            <input type="text" class="form-control" id="recipient4" name="recipient4" placeholder="Recipient #4 (Optional)">
+                        </div>
+
+                        <div class="col-3">
+                            <div class="input-group">
+                                <input class="form-control" id="amount4" name="amount4">
+                                <div class="input-group-append">
+                                    <div class="input-group-text">%</div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+
+                    <div class="form-row mb-3">
+
+                        <div class="col">
+                            <input type="text" class="form-control" id="recipient5" name="recipient5" placeholder="Recipient #5 (Optional)">
+                        </div>
+
+                        <div class="col-3">
+                            <div class="input-group">
+                                <input class="form-control" id="amount5" name="amount5">
+                                <div class="input-group-append">
+                                    <div class="input-group-text">%</div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+
+
+                    
+                    <button type="submit" class="btn btn-primary" id="recipient_submit_btn" disabled="true">Keplr Loading <div class="spinner-border spinner-border-sm" role="status"></div></button>
                 </form>
                 </div>
             </div>

--- a/src/main.js
+++ b/src/main.js
@@ -63,23 +63,13 @@ window.onload = async () => {
     const accounts = await offlineSigner.getAccounts();
     accAddress = accounts[0].address;
 
-    //custom fees object allows us to define defaut gas amounts for executions with this client. If no gasLimit is specificed with the TX the default will be used
-    //amount does not need to be specificed since we are using keplr, the user will select the gas fee and keplr will calculate the final amount
-	const customFees = {
-        exec: {
-            //amount: [{ amount: "50000", denom: "uscrt" }],
-            gas: "100000",
-        }
-    }
-
     // Initialize the client with the offline signer from Keplr extension.
 	client = await SecretNetworkClient.create({
         grpcWebUrl: process.env.GRPCWEB_URL,
         chainId: process.env.CHAIN_ID,
         wallet: offlineSigner,
         walletAddress: accAddress,
-        encryptionUtils: enigmaUtils,
-        customFees: customFees
+        encryptionUtils: enigmaUtils
       });
 
     document.getElementById("account_address").innerHTML = accAddress;
@@ -177,6 +167,7 @@ document.distForm.onsubmit = (e) => {
             }
 
             //execute the contract function
+            //Gas price does not need to be specified when using Keplr. Keplr will prompt the user to choose a gas price (Low/Average/High).
             const tx = await client.tx.compute.executeContract(
                 {
                   sender: accAddress,
@@ -240,6 +231,7 @@ document.distForm.onsubmit = (e) => {
         }
 
         //execute the contract function
+        //Gas price does not need to be specified when using Keplr. Keplr will prompt the user to choose a gas price (Low/Average/High).
         const tx = await client.tx.compute.executeContract(
             {
               sender: accAddress,
@@ -300,6 +292,7 @@ document.adminForm.onsubmit = (e) => {
         }
 
         //execute the contract function
+        //Gas price does not need to be specified when using Keplr. Keplr will prompt the user to choose a gas price (Low/Average/High).
         const tx = await client.tx.compute.executeContract(
             {
                 sender: accAddress,

--- a/src/main.js
+++ b/src/main.js
@@ -2,23 +2,34 @@ const { SecretNetworkClient } = require("secretjs");
 let client;
 let accAddress;
 
+Number.prototype.countDecimals = function () {
+    if(Math.floor(this.valueOf()) === this.valueOf()) return 0;
+    return this.toString().split(".")[1].length || 0; 
+}
+
 const disableButton = () => {
-    document.getElementById("submit_btn").innerHTML = `<div class="spinner-border spinner-border-sm" role="status"><span class="sr-only">Loading...</span></div>`
-    document.getElementById("submit_btn").disabled = true
+    document.getElementById("recipient_submit_btn").innerHTML = `<div class="spinner-border spinner-border-sm" role="status"><span class="sr-only">Loading...</span></div>`
+    document.getElementById("recipient_submit_btn").disabled = true
 }
 
 const enableButton = () => {
-    document.getElementById("submit_btn").innerHTML = `Submit`
-    document.getElementById("submit_btn").disabled = false
+    document.getElementById("recipient_submit_btn").innerHTML = `Submit`
+    document.getElementById("recipient_submit_btn").disabled = false
 }
 
+const validateAddress = (address) => {
+    if (address.length !== 45 && !address.startsWith("secret1") ){
+        throw new Error("Invalid recipient address", address);
+    }
+    return true;
+}
 
 window.onload = async () => {
     //show contract address on page
     document.getElementById("contract_address").innerHTML = process.env.CONTRACT_ADDRESS;
 
-    // Kaple injects the helper function to `window.keplr`.
-    // If `window.getOfflineSigner` or `window.keplr` is null, Keplr extension may be not installed on the browser.
+    // Keplr injects the helper function to `window.keplr`.
+    // If `window.getOfflineSignerOnlyAmino` or `window.keplr` is null, Keplr extension may be not installed or up to date on the browser.
     if (!window.getOfflineSignerOnlyAmino || !window.keplr) {
         alert("Please install or update Keplr Wallet extension");
     }
@@ -65,23 +76,80 @@ window.onload = async () => {
     enableButton();
 };
 
-document.distForm.onsubmit = () => {
-    console.log("submit")
-    //get the new receiving address from the form field
-    let recipient = document.distForm.recipient.value.trim();
+//handle submitting the recipient change form
+document.distForm.onsubmit = (e) => {
+    e.preventDefault();
 
-    //check if address is invalid
-    if (recipient.length !== 45 && !recipient.startsWith("secret1") ){
-        alert("Invalid recipient address");
+    //show loading spinner
+    disableButton();
+
+    //get the new receiving addresses from the form fields
+    let recipients = []
+    try {
+        const recipient1 = document.distForm.recipient1.value.trim();
+        const amount1 = document.distForm.amount1.value.trim();
+        if(recipient1){
+            recipients.push({
+                address: recipient1,
+                amount: amount1
+            })
+        }
+
+        const recipient2 = document.distForm.recipient2.value.trim();
+        const amount2 = document.distForm.amount2.value.trim();
+        if(recipient2){
+            recipients.push({
+                address: recipient2,
+                amount: amount2
+            })
+        }
+
+        const recipient3 = document.distForm.recipient3.value.trim();
+        const amount3 = document.distForm.amount3.value.trim();
+        if(recipient3){
+            recipients.push({
+                address: recipient3,
+                amount: amount3
+            })
+        }
+
+        const recipient4 = document.distForm.recipient4.value.trim();
+        const amount4 = document.distForm.amount4.value.trim();
+        if(recipient4){
+            recipients.push({
+                address: recipient4,
+                amount: amount4
+            })
+        }
+
+        const recipient5 = document.distForm.recipient5.value.trim();
+        const amount5 = document.distForm.amount5.value.trim();
+        if(recipient5){
+            recipients.push({
+                address: recipient5,
+                amount: amount5
+            })
+        }
+
+        //show error if no recipients
+        if (!recipients.length){
+            throw new Error("You must enter at least one recipient!")
+        }
+    } catch (err) {
+        enableButton();
+        alert(`Error: ${err}`);
         return false;
     }
 
-    (async () => {
-        try {
-            //show loading spinner
-            disableButton();
+    (async() => {
+    try{
+        //if only one address was entered, send them 100%
+        if (recipients.length === 1) {
+            validateAddress(recipients[0].address)
+
             await window.keplr.enable(process.env.CHAIN_ID);
 
+            //set dist info with 2 decimal places in rates
             //contract function to execute
             const handleMsg = {
                 change_distribution : {
@@ -89,7 +157,7 @@ document.distForm.onsubmit = () => {
                         decimal_places_in_rates: 2,
                         royalties: [
                             {
-                                recipient: recipient,
+                                recipient: recipients[0].address,
                                 rate: 100
                             }
                         ]
@@ -107,25 +175,87 @@ document.distForm.onsubmit = () => {
                 {
                   gasLimit: 35000,
                 },
-              );
-            console.log(tx);
+            );
 
+            //hide loading spinner
             enableButton();
 
             //check for TX errors
-            if (tx.code !== undefined &&
-                tx.code !== 0) {
-                alert("Failed to execute: " + tx.log || tx.rawLog);
+            if (tx.code !== undefined && tx.code !== 0) {
+                console.log(tx)
+                alert(`Failed to execute:\n${tx.transactionHash}\n` + tx.rawLog);
             } else {
                 alert(`Receiving address successfully changed!\nTX Hash: ${tx.transactionHash}`);
             }
 
-            
-
-        } catch (err) {
-            enableButton();
-            alert(`Error: ${err}`);
+            return true;
         }
+
+        //otherwise calculate rates
+        let distInfo = [];
+
+        recipients.forEach(({address, amount}, index) => {
+            console.log(address, amount)
+            if (isNaN(amount)){
+                throw new Error(`'${amount}' is not a valid percentage.`)
+            }
+            validateAddress(address)
+            const decimals = Number(amount).countDecimals()
+            if (decimals > 3) {
+                throw new Error(`Error: Percentages are limited to 3 decimal places.\n'${amount}' has ${decimals}.`)
+            }
+
+            // convert percentage into rate integers with 5 decimal places
+            // eg 25.12% = 0.25120 = 25120
+            const intAmount = amount * 10e2
+            console.log(intAmount)
+            distInfo.push({
+                recipient: address,
+                rate: intAmount
+            })
+        })
+
+        await window.keplr.enable(process.env.CHAIN_ID);
+
+        //set dist info with 2 decimal places in rates
+        //contract function to execute
+        const handleMsg = {
+            change_distribution : {
+                dist_info: {
+                    decimal_places_in_rates: 5,
+                    royalties: distInfo
+                },
+            }
+        }
+
+        //execute the contract function
+        const tx = await client.tx.compute.executeContract(
+            {
+              sender: accAddress,
+              contract: process.env.CONTRACT_ADDRESS,
+              msg: handleMsg
+            },
+            {
+              gasLimit: 35000,
+            },
+          );
+
+        //hide loading spinner
+        enableButton();
+
+        //check for TX errors
+        if (tx.code !== undefined && tx.code !== 0) {
+            console.log(tx)
+            alert(`Failed to execute:\n${tx.transactionHash}\n` + tx.rawLog);
+        } else {
+            alert(`Receiving address successfully changed!\nTX Hash: ${tx.transactionHash}`);
+        }
+
+    } catch (err) {
+        enableButton();
+        alert(`Error: ${err}`);
+        return false;
+    }
     })();
 
     return false;


### PR DESCRIPTION
Fixes #2 and #4 

Allows the contract admin wallet to enter up to 5 receiving addresses and the percentage that should go to each address.

Also adds a section to change the contract admin address.